### PR TITLE
Fixes for cert signining

### DIFF
--- a/cert.c
+++ b/cert.c
@@ -32,15 +32,17 @@ cert_build_cert(const uint8_t *crypt_publickey)
 int
 cert_sign(struct SignedCert *signed_cert, const uint8_t *provider_secretkey)
 {
+    struct SignedCert cert;
     unsigned long long crypted_signed_data_len = 0;
     unsigned long long signed_data_len =
         sizeof(struct SignedCert) - offsetof(struct SignedCert,
                                              server_publickey) -
         sizeof(signed_cert->end);
+    memcpy(&cert, signed_cert, sizeof cert);
     if (crypto_sign_ed25519
         (signed_cert->server_publickey,
          &crypted_signed_data_len,
-         signed_cert->server_publickey, signed_data_len,
+         cert.server_publickey, signed_data_len,
          provider_secretkey) != 0) {
         return -1;
     }


### PR DESCRIPTION
Hi Yencheng Fu,

Passing a pointer to `size_t` where the function is going to write a `unsigned long long` is dangerous. On some platforms, `size_t` and `unsigned long long` can have different sizes.

Also, overlapping pointers were not supported in libsodium > 0.4.5. This has been fixed, but distros are likely to ship < 1.0 versions for quite some time. So here is a simple workaround to avoid overlapping pointers.
