### PR TITLE
call udp_tune() before bind()

### DIFF
--- a/udp_request.c
+++ b/udp_request.c
@@ -468,6 +468,8 @@ udp_listener_bind(struct context *c)
         return -1;
     }
 
+    udp_tune(c->udp_listener_handle);
+
     evutil_make_socket_closeonexec(c->udp_listener_handle);
     evutil_make_socket_nonblocking(c->udp_listener_handle);
     if (bind
@@ -480,8 +482,6 @@ udp_listener_bind(struct context *c)
         c->udp_listener_handle = -1;
         return -1;
     }
-
-    udp_tune(c->udp_listener_handle);
 
     // resolver socket
     assert(c->udp_resolver_handle == -1);


### PR DESCRIPTION
This is because if you want SO_REUSEPORT you need the sockopt set first.
Without this patch a second copy of dnscrypt-wrapper will bail on trying to bind to an already open socket.
With this patch dnscrypt-wrapper at least has a chance to setsockopt() early enough to use the SO_REUSEPORT feature of kernel 3.9+

This is easy to fix for UDP, TCP is slightly less trivial because we're using libevent.
I'm going to propose TCP with a separate patch.

What do you think?
Maciej
