### PR TITLE
Use the SipHash function instead of a CRC

### DIFF
--- a/dnscrypt.h
+++ b/dnscrypt.h
@@ -127,6 +127,7 @@ struct context {
     uint8_t crypt_publickey[crypto_box_PUBLICKEYBYTES];
     uint8_t crypt_secretkey[crypto_box_SECRETKEYBYTES];
     uint64_t nonce_ts_last;
+    unsigned char hash_key[crypto_shorthash_KEYBYTES];
 };
 
 int dnscrypt_cmp_client_nonce(const uint8_t

--- a/main.c
+++ b/main.c
@@ -407,6 +407,8 @@ main(int argc, const char **argv)
         exit(1);
     }
 
+    randombytes_buf(c.hash_key, sizeof c.hash_key);
+
     if ((c.event_loop = event_base_new()) == NULL) {
         logger(LOG_ERR, "Unable to initialize the event loop.");
         exit(1);

--- a/rfc1035.h
+++ b/rfc1035.h
@@ -3,8 +3,9 @@
 
 #include "compat.h"
 #include "dns-protocol.h"
+#include <sodium.h>
 
-unsigned int questions_crc(struct dns_header *header, size_t plen, char *buff);
+uint64_t questions_hash(struct dns_header *header, size_t plen, char *buff, const unsigned char key[crypto_shorthash_KEYBYTES]);
 int extract_name(struct dns_header *header, size_t plen, unsigned char **pp, char
         *name, int isExtract, int extrabytes);
 int add_resource_record(struct dns_header *header, unsigned int nameoffset, unsigned char **pp, 

--- a/udp_request.h
+++ b/udp_request.h
@@ -13,7 +13,7 @@ typedef struct UDPRequestStatus_ {
 typedef struct UDPRequest_ {
     uint16_t id;
     unsigned int crc;
-        TAILQ_ENTRY(UDPRequest_) queue;
+    TAILQ_ENTRY(UDPRequest_) queue;
     uint8_t client_nonce[crypto_box_HALF_NONCEBYTES];
     uint8_t nmkey[crypto_box_BEFORENMBYTES];
     bool is_dnscrypted;
@@ -27,15 +27,12 @@ typedef struct UDPRequest_ {
     unsigned char retries;
 } UDPRequest;
 
-typedef
-TAILQ_HEAD(TCPRequestQueue_, TCPRequest_)
-    TCPRequestQueue;
-     typedef TAILQ_HEAD(UDPRequestQueue_, UDPRequest_)
-        UDPRequestQueue;
+typedef TAILQ_HEAD(TCPRequestQueue_, TCPRequest_) TCPRequestQueue;
+typedef TAILQ_HEAD(UDPRequestQueue_, UDPRequest_) UDPRequestQueue;
 
-     int udp_listener_bind(struct context *c);
-     int udp_listener_start(struct context *c);
-     void udp_listener_stop(struct context *c);
-     int udp_listener_kill_oldest_request(struct context *c);
+int udp_listener_bind(struct context *c);
+int udp_listener_start(struct context *c);
+void udp_listener_stop(struct context *c);
+int udp_listener_kill_oldest_request(struct context *c);
 
 #endif

--- a/udp_request.h
+++ b/udp_request.h
@@ -12,7 +12,7 @@ typedef struct UDPRequestStatus_ {
 
 typedef struct UDPRequest_ {
     uint16_t id;
-    unsigned int crc;
+    uint64_t hash;
     TAILQ_ENTRY(UDPRequest_) queue;
     uint8_t client_nonce[crypto_box_HALF_NONCEBYTES];
     uint8_t nmkey[crypto_box_BEFORENMBYTES];


### PR DESCRIPTION
The distinction between multiple questions sharing the same query identifier is currently being made using a CRC, which an attacker can predict in addition to having a very small range.
This diff replaces the CRC with SipHash, that uses a secret key and a 64 bit output.
