### PR TITLE
Don't return a valid hash in questions_hash() to signify an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Name
 
 dnscrypt-wrapper - A server-side dnscrypt proxy.
 
-(c) 2012-2013 Yecheng Fu <cofyc.jackson at gmail dot com>
+(c) 2012-2015 Yecheng Fu <cofyc.jackson at gmail dot com>
 
 [![Build Status](https://travis-ci.org/Cofyc/dnscrypt-wrapper.png?branch=master)](https://travis-ci.org/Cofyc/dnscrypt-wrapper)
 

--- a/rfc1035.c
+++ b/rfc1035.c
@@ -176,24 +176,23 @@ extract_name(struct dns_header *header, size_t plen, unsigned char **pp, char
    than hash the raw bytes, since replies might be compressed differently. 
    We ignore case in the names for the same reason. Return all-ones
    if there is not question section. */
-uint64_t
-questions_hash(struct dns_header *header, size_t plen, char *name, const unsigned char key[crypto_shorthash_KEYBYTES])
+int
+questions_hash(uint64_t *hash, struct dns_header *header, size_t plen, char *name, const unsigned char key[crypto_shorthash_KEYBYTES])
 {
   unsigned char qb[MAXDNAME + 4];
-  uint64_t hash = 0xffffffffffffffffULL;
   unsigned char *p = (unsigned char *)(header+1);
   size_t name_len;
 
   if (ntohs(header->qdcount) != 1 ||
       !extract_name(header, plen, &p, name, 1, 4) ||
       (name_len = strlen(name)) > (sizeof qb - 4)) {
-      return hash;
+      return -1;
   }
   memcpy(qb, name, name_len);
   memcpy(qb + name_len, p, 4);
-  crypto_shorthash((unsigned char *) &hash, qb, name_len + 4ULL, key);
+  crypto_shorthash((unsigned char *) hash, qb, name_len + 4ULL, key);
 
-  return hash;
+  return 0;
 }
 
 static unsigned char *skip_name(unsigned char *ansp, struct dns_header *header, size_t plen, int extrabytes)

--- a/rfc1035.h
+++ b/rfc1035.h
@@ -5,7 +5,7 @@
 #include "dns-protocol.h"
 #include <sodium.h>
 
-uint64_t questions_hash(struct dns_header *header, size_t plen, char *buff, const unsigned char key[crypto_shorthash_KEYBYTES]);
+int questions_hash(uint64_t *hash, struct dns_header *header, size_t plen, char *buff, const unsigned char key[crypto_shorthash_KEYBYTES]);
 int extract_name(struct dns_header *header, size_t plen, unsigned char **pp, char
         *name, int isExtract, int extrabytes);
 int add_resource_record(struct dns_header *header, unsigned int nameoffset, unsigned char **pp, 


### PR DESCRIPTION
Use a proper return code and store the hash in a given pointer instead.

In addition, if the packet is not a valid DNS query, I don't think ignoring the hash is the right thing to do.

Either something is broken or we're under attack, or someone is fuzzing the proxy. Either way, normal applications have no reason to try sending non-DNS queries to the proxy, so we'd better print an error and drop the packet.