### PR TITLE
Plug memory leak

### DIFF
--- a/udp_request.c
+++ b/udp_request.c
@@ -247,12 +247,16 @@ self_serve_cert_file(struct context *c, struct dns_header *header,
         GETSHORT(qtype, p);
         if (qtype == T_TXT && strcasecmp(c->provider_name, c->namebuff) == 0) {
             // reply with signed certificate
-            size_t size = 1 + sizeof(struct SignedCert);
-            uint8_t *txt = malloc(size);
-            if (!txt)
-                return -1;
-            *txt = sizeof(struct SignedCert);
-            memcpy(txt + 1, &c->signed_cert, sizeof(struct SignedCert));
+            const size_t size = 1 + sizeof(struct SignedCert);
+            static uint8_t *txt;
+
+            if (!txt) {
+                txt = malloc(size);
+                if (!txt)
+                    return -1;
+                *txt = sizeof(struct SignedCert);
+                memcpy(txt + 1, &c->signed_cert, sizeof(struct SignedCert));
+            }
             if (add_resource_record
                 (header, nameoffset, &ansp, 0, NULL, T_TXT, C_IN, "t", size,
                  txt)) {

--- a/version.h
+++ b/version.h
@@ -2,6 +2,6 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-const char *the_version = "0.1.14.8.g915e06c";
+const char *the_version = "0.1.14.19.g137f602";
 
 #endif


### PR DESCRIPTION
This plugs a memory leak: the `malloc()`ed buffer for the TXT records was never released.
Since the certificate doesn't change (for now), we actually only need to call `malloc()` once.