### PR TITLE
Add a new switch to explicitly allow unauthenticated queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,26 @@ Optional, add `-d/--daemonize` flag to run as daemon.
 
 Run `./dnscrypt-wrapper -h` to view command line options.
 
+Running unauthenticated DNS and the dnscrypt service on the same port
+=====================================================================
+
+By default, and with the exception of records used for the
+certificates, only queries using the DNSCrypt protocol will be
+accepted.
+
+If you want to run a service only accessible using DNSCrypt, this is
+what you want.
+
+If you want to run a service accessible both with and without
+DNSCrypt, what you usually want is to keep the standard DNS port for
+the unauthenticated DNS service (53), and use a different port for
+DNSCrypt. You don't have to change anything for this either.
+
+However, if you want to run both on the same port, maybe because only
+port 53 is reachable on your server, you can add the `-U`
+(`--unauthenticated`) switch to the command-line. This is not
+recommended.
+
 See also
 ========
     

--- a/dnscrypt.h
+++ b/dnscrypt.h
@@ -110,6 +110,7 @@ struct context {
 
     /* Process stuff. */
     bool daemonize;
+    bool allow_not_dnscrypted;
     char *pidfile;
     char *user;
     uid_t user_id;

--- a/main.c
+++ b/main.c
@@ -202,6 +202,8 @@ main(int argc, const char **argv)
         OPT_BOOLEAN('d', "daemonize", &c.daemonize,
                     "run as daemon (default: off)"),
         OPT_STRING('p', "pidfile", &c.pidfile, "pid stored file"),
+        OPT_BOOLEAN('u', "unauthenticated", &c.allow_not_dnscrypted,
+                    "allow and forward unauthenticated queries (default: off)"),
         OPT_BOOLEAN('V', "verbose", &verbose,
                     "show verbose logs (specify more -VVV to increase verbosity)"),
         OPT_STRING('l', "logfile", &c.logfile,

--- a/main.c
+++ b/main.c
@@ -202,7 +202,7 @@ main(int argc, const char **argv)
         OPT_BOOLEAN('d', "daemonize", &c.daemonize,
                     "run as daemon (default: off)"),
         OPT_STRING('p', "pidfile", &c.pidfile, "pid stored file"),
-        OPT_BOOLEAN('u', "unauthenticated", &c.allow_not_dnscrypted,
+        OPT_BOOLEAN('U', "unauthenticated", &c.allow_not_dnscrypted,
                     "allow and forward unauthenticated queries (default: off)"),
         OPT_BOOLEAN('V', "verbose", &verbose,
                     "show verbose logs (specify more -VVV to increase verbosity)"),

--- a/tcp_request.c
+++ b/tcp_request.c
@@ -158,6 +158,10 @@ client_proxy_read_cb(struct bufferevent *const client_proxy_bev,
             return;
         }
         tcp_request->is_dnscrypted = true;
+    } else if (!c->allow_not_dnscrypted) {
+        logger(LOG_DEBUG, "Unauthenticated query received over TCP");
+        tcp_request_kill(tcp_request);
+        return;
     } else {
         tcp_request->is_dnscrypted = false;
     }


### PR DESCRIPTION
By default, dnscrypt-wrapper forwards non-dnscrypted queries to the upstream server.

But people may want to run a service that only accepts authenticated queries. Some might think that this is already the case and don't know that the dnscrypt port can also work with regular DNS queries.

And to accept both regular and dnscrypted queries, the easiest, fastest and safest way is to use different ports.

This pull request refuses unauthenticated queries by default, and introduces a new switch, `-U`, to explicitly allow them if needed.