### PR TITLE
Inherit install path from environment if present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,11 @@ STRIP ?= strip
 ALL_CFLAGS = $(CFLAGS) $(BASIC_CFLAGS)
 ALL_LDFLAGS = $(LDFLAGS) $(BASIC_LDFLAGS)
 
-prefix = /usr/local
+ifdef PREFIX
+	prefix = $(PREFIX)
+else
+	prefix = /usr/local
+endif
 bindir = $(prefix)/bin
 sbindir = $(prefix)/sbin
 sharedir = $(prefix)/share


### PR DESCRIPTION
I've been working on adding this project to the FreeBSD Ports Collection. During this, I found that the install path prefix being hard-coded to /usr/local in Makefile breaks the port build. This is because the port is first made in a working directory before installation or packaging. The FreeBSD Porter's Handbook [speaks in detail](https://www.freebsd.org/doc/en_US.ISO8859-1/books/porters-handbook/porting-prefix.html) about this issue and advises inheriting $PREFIX from the environment. So, I'm suggesting a change where $prefix will be set to $PREFIX if the latter is present, otherwise it is set to "/usr/local" as before.