### PR TITLE
Support for multiple keys / seamless key rotation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_script:
  - sudo apt-get install libevent-dev
  - git clone git://github.com/jedisct1/libsodium.git
  - cd libsodium
- - git checkout 0.4.1
+ - git checkout 1.0.0
  - ./autogen.sh
- - ./configure --disable-dependency-tracking
+ - ./configure --disable-dependency-tracking --enable-minimal
  - sudo make install
  - sudo ldconfig
  - cd ..

--- a/dnscrypt.h
+++ b/dnscrypt.h
@@ -131,11 +131,14 @@ struct context {
     uint8_t provider_publickey[crypto_sign_ed25519_PUBLICKEYBYTES];
     uint8_t provider_secretkey[crypto_sign_ed25519_SECRETKEYBYTES];
     char *crypt_secretkey_file;
-    KeyPair keypair;
+    KeyPair *keypairs;
+    size_t keypairs_count;
     uint64_t nonce_ts_last;
     unsigned char hash_key[crypto_shorthash_KEYBYTES];
 };
 
+const KeyPair * find_keypair(const struct context *c,
+                             const unsigned char magic_query[DNSCRYPT_MAGIC_HEADER_LEN]);
 int dnscrypt_cmp_client_nonce(const uint8_t
                               client_nonce[crypto_box_HALF_NONCEBYTES],
                               const uint8_t *const buf, const size_t len);

--- a/dnscrypt.h
+++ b/dnscrypt.h
@@ -138,7 +138,8 @@ struct context {
 };
 
 const KeyPair * find_keypair(const struct context *c,
-                             const unsigned char magic_query[DNSCRYPT_MAGIC_HEADER_LEN]);
+                             const unsigned char magic_query[DNSCRYPT_MAGIC_HEADER_LEN],
+                             const size_t dns_query_len);
 int dnscrypt_cmp_client_nonce(const uint8_t
                               client_nonce[crypto_box_HALF_NONCEBYTES],
                               const uint8_t *const buf, const size_t len);
@@ -195,7 +196,7 @@ struct dnscrypt_query_header {
     uint8_t mac[crypto_box_MACBYTES];
 };
 
-int dnscrypt_server_uncurve(struct context *c,
+int dnscrypt_server_uncurve(struct context *c, const KeyPair *keypair,
                             uint8_t client_nonce[crypto_box_HALF_NONCEBYTES],
                             uint8_t nmkey[crypto_box_BEFORENMBYTES],
                             uint8_t *const buf, size_t * const lenp);

--- a/dnscrypt.h
+++ b/dnscrypt.h
@@ -11,6 +11,12 @@
 #include <event2/util.h>
 #include <sodium.h>
 
+#if SODIUM_LIBRARY_VERSION_MAJOR < 7
+# define sodium_allocarray(C, S) calloc(C, S)
+# define sodium_malloc(S) malloc(S)
+# define sodium_free(P) free(P)
+#endif
+
 #define DNS_QUERY_TIMEOUT 10
 
 #define DNS_MAX_PACKET_SIZE_UDP_RECV (65536U - 20U - 8U)

--- a/main.c
+++ b/main.c
@@ -309,6 +309,9 @@ main(int argc, const char **argv)
                        c.crypt_secretkey_file);
                 exit(0);
             }
+            logger(LOG_ERR, "The new certificate was not saved - "
+                   "Maybe the %s file already exists - please delete it first.",
+                   c.crypt_secretkey_file);
             exit(1);
         } else {
             printf(" failed.\n");

--- a/main.c
+++ b/main.c
@@ -297,7 +297,7 @@ main(int argc, const char **argv)
     if (gen_crypt_keypair) {
         printf("Generate crypt key pair...");
         fflush(stdout);
-        if ((c.keypairs = malloc(sizeof *c.keypairs)) == NULL)
+        if ((c.keypairs = sodium_malloc(sizeof *c.keypairs)) == NULL)
             exit(1);
         if (crypto_box_keypair(c.keypairs->crypt_publickey,
                                c.keypairs->crypt_secretkey) == 0) {

--- a/main.c
+++ b/main.c
@@ -250,6 +250,8 @@ main(int argc, const char **argv)
     if (!c.provider_cert_file)
         c.provider_cert_file = "dnscrypt.cert";
 
+    c.keypairs = NULL;
+
     if (gen_provider_keypair) {
         uint8_t provider_publickey[crypto_sign_ed25519_PUBLICKEYBYTES];
         uint8_t provider_secretkey[crypto_sign_ed25519_SECRETKEYBYTES];
@@ -295,11 +297,13 @@ main(int argc, const char **argv)
     if (gen_crypt_keypair) {
         printf("Generate crypt key pair...");
         fflush(stdout);
-        if (crypto_box_keypair(c.keypair.crypt_publickey,
-                               c.keypair.crypt_secretkey) == 0) {
+        if ((c.keypairs = malloc(sizeof *c.keypairs)) == NULL)
+            exit(1);
+        if (crypto_box_keypair(c.keypairs->crypt_publickey,
+                               c.keypairs->crypt_secretkey) == 0) {
             printf(" ok.\n");
             if (write_to_file(c.crypt_secretkey_file,
-                              (char *)c.keypair.crypt_secretkey,
+                              (char *)c.keypairs->crypt_secretkey,
                               crypto_box_SECRETKEYBYTES) == 0) {
                 printf("Secret key stored in %s\n",
                        c.crypt_secretkey_file);
@@ -320,21 +324,52 @@ main(int argc, const char **argv)
     if (logger_verbosity > LOG_DEBUG)
         logger_verbosity = LOG_DEBUG;
 
-    if (read_from_file(c.crypt_secretkey_file,
-                       (char *)c.keypair.crypt_secretkey,
-                       crypto_box_SECRETKEYBYTES) != 0) {
+    char *crypt_secretkey_files, *crypt_secretkey_file;
+    size_t keypair_id;
+
+    c.keypairs_count = 0U;
+    if ((crypt_secretkey_files = strdup(c.crypt_secretkey_file)) == NULL)
         exit(1);
+    for (crypt_secretkey_file = strtok(crypt_secretkey_files, ",");
+         crypt_secretkey_file != NULL;
+         crypt_secretkey_file = strtok(NULL, ",")) {
+        c.keypairs_count++;
     }
-    if (crypto_scalarmult_base(c.keypair.crypt_publickey,
-                               c.keypair.crypt_secretkey) != 0) {
-        exit(1);
+    if (c.keypairs_count <= 0U) {
+        logger(LOG_ERR, "You must specify --crypt-secretkey-file.\n\n");
+        argparse_usage(&argparse);
+        exit(0);
     }
-    char fingerprint[80];
-    dnscrypt_key_to_fingerprint(fingerprint, c.keypair.crypt_publickey);
-    logger(LOG_INFO, "Crypt public key fingerprint: %s", fingerprint);
+    memcpy(crypt_secretkey_files, c.crypt_secretkey_file, strlen(c.crypt_secretkey_file) + 1U);
+    c.keypairs = sodium_allocarray(c.keypairs_count, sizeof *c.keypairs);
+    keypair_id = 0U;
+    for (crypt_secretkey_file = strtok(crypt_secretkey_files, ",");
+         crypt_secretkey_file != NULL;
+         crypt_secretkey_file = strtok(NULL, ",")) {
+        char fingerprint[80];
+
+        if (read_from_file(crypt_secretkey_file,
+                           (char *)c.keypairs[keypair_id].crypt_secretkey,
+                           crypto_box_SECRETKEYBYTES) != 0) {
+            logger(LOG_ERR, "Unable to read %s", crypt_secretkey_file);
+            exit(1);
+        }
+        if (crypto_scalarmult_base(c.keypairs[keypair_id].crypt_publickey,
+                                   c.keypairs[keypair_id].crypt_secretkey) != 0)
+            exit(1);
+        dnscrypt_key_to_fingerprint(fingerprint, c.keypairs->crypt_publickey);
+        logger(LOG_INFO, "Crypt public key fingerprint for %s: %s",
+               crypt_secretkey_file, fingerprint);
+        keypair_id++;
+    }
+    free(crypt_secretkey_files);
 
     // generate signed certificate
     if (gen_cert_file) {
+        if (c.keypairs_count != 1U) {
+            logger(LOG_ERR, "A certificate can only store a single key");
+            exit(1);
+        }
         if (read_from_file
             (c.provider_publickey_file, (char *)c.provider_publickey,
              crypto_sign_ed25519_PUBLICKEYBYTES) == 0
@@ -346,7 +381,7 @@ main(int argc, const char **argv)
         }
         logger(LOG_NOTICE, "Generating pre-signed certificate.");
         struct SignedCert *signed_cert =
-            cert_build_cert(c.keypair.crypt_publickey, cert_file_expire_days);
+            cert_build_cert(c.keypairs->crypt_publickey, cert_file_expire_days);
         if (!signed_cert || cert_sign(signed_cert, c.provider_secretkey) != 0) {
             logger(LOG_NOTICE, "Failed.");
             exit(1);

--- a/tcp_request.c
+++ b/tcp_request.c
@@ -147,9 +147,9 @@ client_proxy_read_cb(struct bufferevent *const client_proxy_bev,
     // decrypt if encrypted
     struct dnscrypt_query_header *dnscrypt_header =
         (struct dnscrypt_query_header *)dns_query;
-    debug_assert(sizeof c->keypair.crypt_publickey >= DNSCRYPT_MAGIC_HEADER_LEN);
+    debug_assert(sizeof c->keypairs->crypt_publickey >= DNSCRYPT_MAGIC_HEADER_LEN);
     if (memcmp
-        (dnscrypt_header->magic_query, c->keypair.crypt_publickey,
+        (dnscrypt_header->magic_query, c->keypairs->crypt_publickey,
          DNSCRYPT_MAGIC_HEADER_LEN) == 0
         || memcmp
         (dnscrypt_header->magic_query, CERT_OLD_MAGIC_HEADER,

--- a/udp_request.c
+++ b/udp_request.c
@@ -356,10 +356,10 @@ client_to_proxy_cb(evutil_socket_t client_proxy_handle, short ev_flags,
     // decrypt if encrypted
     struct dnscrypt_query_header *dnscrypt_header =
         (struct dnscrypt_query_header *)dns_query;
-    assert(sizeof c->keypair.crypt_publickey >= DNSCRYPT_MAGIC_HEADER_LEN);
+    assert(sizeof c->keypairs->crypt_publickey >= DNSCRYPT_MAGIC_HEADER_LEN);
 
     if (memcmp
-        (dnscrypt_header->magic_query, c->keypair.crypt_publickey,
+        (dnscrypt_header->magic_query, c->keypairs->crypt_publickey,
          DNSCRYPT_MAGIC_HEADER_LEN) == 0
         || memcmp
         (dnscrypt_header->magic_query, CERT_OLD_MAGIC_HEADER,


### PR DESCRIPTION
 Accept multiple keys.

I still need to update the README file, but here is how to seamlessly switch to a new key:

    1) Create the first key and its related certificate:

    $ dnscrypt-wrapper --gen-crypt-keypair --crypt-secretkey-file=1.key
    $ dnscrypt-wrapper --gen-cert-file --crypt-secretkey-file=1.key --provider-cert-file=1.cert

    Run the server:

    $ dnscrypt-wrapper --resolver-address=114.114.114.114 \
                       --provider-name=2.dnscrypt-example.org \
                       --listen-address=0.0.0.0:443 \
                       --crypt-secretkey-file=1.key \
                       --provider-cert-file=1.cert

    2) Before 1.key expires, create a fresh new key and a certificate for it:

    $ dnscrypt-wrapper --gen-crypt-keypair --crypt-secretkey-file=2.key
    $ dnscrypt-wrapper --gen-cert-file --crypt-secretkey-file=2.key --provider-cert-file=2.cert

    Run a new instance of the server, which is going to publish the certificate
    for the new key, but still accept queries using the previous key in addition
    to the new one (notice the --crypt-secretkey-file= line, which can now include
    an arbitrary number of keys):

    $ dnscrypt-wrapper --resolver-address=114.114.114.114 \
                       --provider-name=2.dnscrypt-example.org \
                       --listen-address=0.0.0.0:443 \
                       --crypt-secretkey-file=1.key,2.key \
                       --provider-cert-file=2.cert

    3) Wait 1 hour and remove the old key:

    $ dnscrypt-wrapper --resolver-address=114.114.114.114 \
                       --provider-name=2.dnscrypt-example.org \
                       --listen-address=0.0.0.0:443 \
                       --crypt-secretkey-file=2.key \
                       --provider-cert-file=2.cert