### PR TITLE
Allow dnscrypt-wrapper to be installed into another DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,8 +199,8 @@ version.h: FORCE
 	@./gen-version.sh
 
 install: all
-	$(INSTALL) -d -m 755 '$(sbindir)'
-	$(INSTALL) -p dnscrypt-wrapper '$(sbindir)'
+	$(INSTALL) -d -m 755 '$(DESTDIR)$(sbindir)'
+	$(INSTALL) -p dnscrypt-wrapper '$(DESTDIR)$(sbindir)'
 
 uninstall:
 	$(RM) $(sbindir)/dnscrypt-wrapper


### PR DESCRIPTION
Example:
make configure
./configure --prefix=/usr
make
make install DESTDIR=/tmp/dnscrypt-wrapper