### PR TITLE
Updated FreeBSD installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ On Linux:
 
 On FreeBSD:
 
-    $ pkg_add -r gmake autoconf
-    $ pkg_add -r libevent2
-    $ gmake LDFLAGS='-L/usr/local/lib/event2 -L/usr/local/lib' CFLAGS=-I/usr/local/include
+    $ pkg install dnscrypt-wrapper
 
 On OpenBSD:
 


### PR DESCRIPTION
I created a FreeBSD port of dnscrypt-wrapper and it has been accepted to the official ports tree, so it is can now be installed much more easily. More info here: http://www.freshports.org/dns/dnscrypt-wrapper