### PR TITLE
Send a short packet with TC set if the query_len < response_len

### DIFF
--- a/udp_request.h
+++ b/udp_request.h
@@ -18,6 +18,7 @@ typedef struct UDPRequest_ {
     uint64_t hash;
     uint16_t id;
     uint16_t gen;
+    uint16_t len;
     uint8_t client_nonce[crypto_box_HALF_NONCEBYTES];
     uint8_t nmkey[crypto_box_BEFORENMBYTES];
     struct sockaddr_storage client_sockaddr;


### PR DESCRIPTION
This is part of the second version of the protocol, is supported by the client since dnscrypt-proxy 1.3.3, and prevents DNS amplification attacks.