### PR TITLE
Fix compiler/linker flags handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all::
 
 ### Defaults
 
-BASIC_CFLAGS = -O2 -std=c99 -Wall -I./argparse
+BASIC_CFLAGS = -std=c99 -Wall -I./argparse
 BASIC_LDFLAGS = -lm -lsodium
 
 # Guard against environment variables
@@ -29,13 +29,13 @@ uname_P := $(shell sh -c 'uname -p 2>/dev/null || echo not')
 uname_V := $(shell sh -c 'uname -v 2>/dev/null || echo not')
 
 # CFLAGS and LDFLAGS are for users to override
-CFLAGS = -g -O2 -Wall
-LDFLAGS =
+CFLAGS ?= -g -O2 -Wall
+LDFLAGS ?=
 STRIP ?= strip
 
 # We use ALL_* variants
-ALL_CFLAGS = $(CFLAGS) $(BASIC_CFLAGS)
-ALL_LDFLAGS = $(LDFLAGS) $(BASIC_LDFLAGS)
+ALL_CFLAGS = $(BASIC_CFLAGS) $(CFLAGS)
+ALL_LDFLAGS = $(BASIC_LDFLAGS) $(LDFLAGS)
 
 ifdef PREFIX
 	prefix = $(PREFIX)

--- a/argparse/Makefile
+++ b/argparse/Makefile
@@ -1,10 +1,13 @@
 # Defaults
-BASIC_CFLAGS = -Wall -O3 -g -ggdb -fPIC
+CFLAGS ?= -O3 -g -ggdb
+LDFLAGS ?=
+
+BASIC_CFLAGS = -Wall -fPIC
 BASIC_LDFLAGS = -lm
 
 # We use ALL_* variants
-ALL_CFLAGS = $(CFLAGS) $(BASIC_CFLAGS)
-ALL_LDFLAGS = $(LDFLAGS) $(BASIC_LDFLAGS)
+ALL_CFLAGS = $(BASIC_CFLAGS) $(CFLAGS)
+ALL_LDFLAGS = $(BASIC_LDFLAGS) $(LDFLAGS)
 
 LIBNAME=libargparse
 


### PR DESCRIPTION
- Make flags always overridable by user ({C,LD}FLAGS ?=)
- Move customizable bits (```-O*```, ```-g*```) into default CFLAGS/LDFLAGS, and leave mandatory ones in BASIC_{C,LD}FLAGS
- Apply BASIC_{C,LD}FLAGS before {C,LD}FLAGS, because the latter may
  contain e.g. additional -I/-L paths and these should come after local
  ones such as ```-I./argparse```