### PR TITLE
Remove duplicates/obsolete parts

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -18,33 +18,12 @@ dnscrypt-wrapper is modified from dnscrypt-proxy, written by Yecheng Fu
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-/*
- * Copyright (c) 2011-2015 Frank Denis <j at pureftpd dot org>
- *
- * Permission to use, copy, modify, and/or distribute this software for any 
- * purpose with or without fee is hereby granted, provided that the above
- * copyright notice and this permission notice appear in all copies.
- *
- * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
- * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
- * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR 
- * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
- * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
- * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
- * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- */
-
 ====
 
 The externally maintained libraries used by dnscrypt-wrapper are:
 
-  - NaCl (http://nacl.cr.yp.to/). Public domain.
-
   - libevent (http://libevent.org/). 3-clause BSD license.
     See libevent/LICENSE.
-
-  - salsa20_random.c reuses code from OpenBSD written by Damien Miller.
-    BSD license.
 
   - argparse, See argparse/LICENSE.
 


### PR DESCRIPTION
The license of dnscrypt-proxy and dnscrypt-wrapper are exactly the same, so just keep the one from dnscrypt-wrapper.
Also, salsa20_random and other crypto operations are not part of this package any more.