### PR TITLE
Fix crypt public key fingerprint log.

### DIFF
--- a/main.c
+++ b/main.c
@@ -412,7 +412,7 @@ main(int argc, const char **argv)
         if (crypto_scalarmult_base(c.keypairs[keypair_id].crypt_publickey,
                                    c.keypairs[keypair_id].crypt_secretkey) != 0)
             exit(1);
-        dnscrypt_key_to_fingerprint(fingerprint, c.keypairs->crypt_publickey);
+        dnscrypt_key_to_fingerprint(fingerprint, c.keypairs[keypair_id].crypt_publickey);
         logger(LOG_INFO, "Crypt public key fingerprint for %s: %s",
                crypt_secretkey_file, fingerprint);
         keypair_id++;


### PR DESCRIPTION
dnscrypt_key_to_fingerprint was not offseting the key based on
keypair_id resulting in always fingerprinting the first key in the list.

# Before
```
vagrant@vagrant:/vagrant$ sudo ./dnscrypt-wrapper
--resolver-address=127.0.0.1:53 --listen-address=0.0.0.0:8443
--provider-name=2.dnscrypt-cert.example.com
--crypt-secretkey-file=keys1/1.key,keys2/1.key
--provider-cert-file=keys1/1.cert -VVVVV
[2465] 18 Nov 07:15:49.137 [info] [main.c:417] Crypt public key
fingerprint for keys1/1.key:
4F9D:075B:7336:7196:80A9:104A:3563:44ED:F23A:FA30:0555:CBA1:9284:8529:6A73:2E2F
[2465] 18 Nov 07:15:49.138 [info] [main.c:417] Crypt public key
fingerprint for keys2/1.key:
4F9D:075B:7336:7196:80A9:104A:3563:44ED:F23A:FA30:0555:CBA1:9284:8529:6A73:2E2F
```

# After
```
vagrant@vagrant:/vagrant$ sudo ./dnscrypt-wrapper
--resolver-address=127.0.0.1:53 --listen-address=0.0.0.0:8443
--provider-name=2.dnscrypt-cert.example.com
--crypt-secretkey-file=keys1/1.key,keys2/1.key
--provider-cert-file=keys1/1.cert -VVVVV
[2502] 18 Nov 07:16:01.084 [info] [main.c:417] Crypt public key
fingerprint for keys1/1.key:
4F9D:075B:7336:7196:80A9:104A:3563:44ED:F23A:FA30:0555:CBA1:9284:8529:6A73:2E2F
[2502] 18 Nov 07:16:01.084 [info] [main.c:417] Crypt public key
fingerprint for keys2/1.key:
8E76:BE52:C1A7:0B67:22CE:D2EA:7CD1:EA17:D8F9:6545:A370:8F17:2934:95B1:7D30:7E36
```