### PR TITLE
refactor `self_serve_cert_file` to only use a common `dnscrypt_self_serve_cert_file` for both UDP and TCP.

### DIFF
--- a/dnscrypt.c
+++ b/dnscrypt.c
@@ -303,3 +303,78 @@ dnscrypt_server_curve(struct context *c,
     *lenp = len + DNSCRYPT_REPLY_HEADER_SIZE;
     return 0;
 }
+
+/**
+ * Return 0 if served.
+ */
+int
+dnscrypt_self_serve_cert_file(struct context *c, struct dns_header *header,
+                     size_t *dns_query_len)
+{
+    unsigned char *p;
+    unsigned char *ansp;
+    int q;
+    int qtype;
+    unsigned int nameoffset;
+    p = (unsigned char *)(header + 1);
+    int anscount = 0;
+    /* determine end of questions section (we put answers there) */
+    if (!(ansp = skip_questions(header, *dns_query_len))) {
+        return -1;
+    }
+    for (q = ntohs(header->qdcount); q != 0; q--) {
+        /* save pointer to name for copying into answers */
+        nameoffset = p - (unsigned char *)header;
+
+        if (!extract_name(header, *dns_query_len, &p, c->namebuff, 1, 4)) {
+            return -1;
+        }
+        GETSHORT(qtype, p);
+        if (qtype == T_TXT && strcasecmp(c->provider_name, c->namebuff) == 0) {
+            // reply with signed certificate
+            const size_t size = 1 + sizeof(struct SignedCert);
+            static uint8_t **txt;
+
+            // Allocate static buffers containing the certificates.
+            // This is only called once the first time a TXT request is made.
+            if(!txt) {
+                txt = calloc(c->signed_certs_count, sizeof(uint8_t *));
+                if(!txt) {
+                    return -1;
+                }
+                for (int i=0; i < c->signed_certs_count; i++) {
+                    *(txt + i) = malloc(size);
+                    if (!*(txt + i))
+                        return -1;
+                    **(txt + i) = sizeof(struct SignedCert);
+                    memcpy(*(txt + i) + 1, c->signed_certs + i, sizeof(struct SignedCert));
+                }
+            }
+
+            for (int i=0; i < c->signed_certs_count; i++) {
+                if (add_resource_record
+                    (header, nameoffset, &ansp, 0, NULL, T_TXT, C_IN, "t", size,
+                     *(txt + i))) {
+                    anscount++;
+                } else {
+                    return -1;
+                }
+            }
+            /* done all questions, set up header and return length of result */
+            /* clear authoritative and truncated flags, set QR flag */
+            header->hb3 = (header->hb3 & ~(HB3_AA | HB3_TC)) | HB3_QR;
+            /* set RA flag */
+            header->hb4 |= HB4_RA;
+
+            SET_RCODE(header, NOERROR);
+            header->ancount = htons(anscount);
+            header->nscount = htons(0);
+            header->arcount = htons(0);
+            *dns_query_len = ansp - (unsigned char *)header;
+
+            return 0;
+          }
+    }
+    return -1;
+}
+

--- a/dnscrypt.h
+++ b/dnscrypt.h
@@ -212,4 +212,14 @@ int dnscrypt_server_curve(struct context *c,
                           uint8_t nmkey[crypto_box_BEFORENMBYTES],
                           uint8_t *const buf, size_t * const lenp,
                           const size_t max_len);
+/**
+ * Given a DNS request,iterate over the question sections.
+ * If a TXT request for provider name is made, adds the certs as TXT records
+ * and return 0. dns_query_len is updated to reflect the size of the DNS packet.
+ * return non-zero in case of failure.
+ * */
+int dnscrypt_self_serve_cert_file(struct context *c,
+                                  struct dns_header *header,
+                                  size_t *dns_query_len);
+
 #endif

--- a/tcp_request.c
+++ b/tcp_request.c
@@ -86,82 +86,21 @@ static int
 self_serve_cert_file(struct context *c, struct dns_header *header,
                      size_t dns_query_len, TCPRequest *tcp_request)
 {
-    unsigned char *p;
-    unsigned char *ansp;
     uint8_t dns_query_len_buf[2];
-    int q;
-    int qtype;
-    unsigned int nameoffset;
-    p = (unsigned char *)(header + 1);
-    int anscount = 0;
-    /* determine end of questions section (we put answers there) */
-    if (!(ansp = skip_questions(header, dns_query_len))) {
-        return -1;
-    }
-    for (q = ntohs(header->qdcount); q != 0; q--) {
-        /* save pointer to name for copying into answers */
-        nameoffset = p - (unsigned char *)header;
-
-        if (!extract_name(header, dns_query_len, &p, c->namebuff, 1, 4)) {
+    if (dnscrypt_self_serve_cert_file(c, header, &dns_query_len) == 0) {
+        dns_query_len_buf[0] = (dns_query_len >> 8) & 0xff;
+        dns_query_len_buf[1] = dns_query_len & 0xff;
+        if (bufferevent_write(tcp_request->client_proxy_bev,
+                        dns_query_len_buf, (size_t) 2U) != 0 ||
+            bufferevent_write(tcp_request->client_proxy_bev, (void *)header,
+                            (size_t)dns_query_len) != 0) {
+            tcp_request_kill(tcp_request);
             return -1;
         }
-        GETSHORT(qtype, p);
-        if (qtype == T_TXT && strcasecmp(c->provider_name, c->namebuff) == 0) {
-            // reply with signed certificate
-            const size_t size = 1 + sizeof(struct SignedCert);
-            static uint8_t **txt;
-
-            if(!txt) {
-                txt = calloc(c->signed_certs_count, sizeof(uint8_t *));
-                if(!txt) {
-                    return -1;
-                }
-                for (int i=0; i < c->signed_certs_count; i++) {
-                    if (!*(txt + i)) {
-                        *(txt + i) = malloc(size);
-                        if (!*(txt + i))
-                            return -1;
-                        **(txt + i) = sizeof(struct SignedCert);
-                        memcpy(*(txt + i) + 1, c->signed_certs + i, sizeof(struct SignedCert));
-                    }
-                }
-            }
-
-            for (int i=0; i < c->signed_certs_count; i++) {
-                if (add_resource_record
-                    (header, nameoffset, &ansp, 0, NULL, T_TXT, C_IN, "t", size,
-                     *(txt + i))) {
-                    anscount++;
-                } else {
-                    return -1;
-                }
-            }
-            /* done all questions, set up header and return length of result */
-            /* clear authoritative and truncated flags, set QR flag */
-            header->hb3 = (header->hb3 & ~(HB3_AA | HB3_TC)) | HB3_QR;
-            /* set RA flag */
-            header->hb4 |= HB4_RA;
-
-            SET_RCODE(header, NOERROR);
-            header->ancount = htons(anscount);
-            header->nscount = htons(0);
-            header->arcount = htons(0);
-            dns_query_len = ansp - (unsigned char *)header;
-
-            dns_query_len_buf[0] = (dns_query_len >> 8) & 0xff;
-            dns_query_len_buf[1] = dns_query_len & 0xff;
-            if (bufferevent_write(tcp_request->client_proxy_bev,
-                              dns_query_len_buf, (size_t) 2U) != 0 ||
-                bufferevent_write(tcp_request->client_proxy_bev, (void *)header,
-                                  (size_t)dns_query_len) != 0) {
-                tcp_request_kill(tcp_request);
-                return -1;
-            }
-            bufferevent_enable(tcp_request->client_proxy_bev, EV_WRITE);
-            bufferevent_free(tcp_request->proxy_resolver_bev);
-            tcp_request->proxy_resolver_bev = NULL;
-            return 0;
-        }
+        bufferevent_enable(tcp_request->client_proxy_bev, EV_WRITE);
+        bufferevent_free(tcp_request->proxy_resolver_bev);
+        tcp_request->proxy_resolver_bev = NULL;
+        return 0;
     }
     return -1;
 }

--- a/udp_request.c
+++ b/udp_request.c
@@ -234,67 +234,7 @@ static int
 self_serve_cert_file(struct context *c, struct dns_header *header,
                      size_t dns_query_len, UDPRequest *udp_request)
 {
-    unsigned char *p;
-    unsigned char *ansp;
-    int q;
-    int qtype;
-    unsigned int nameoffset;
-    p = (unsigned char *)(header + 1);
-    int anscount = 0;
-    /* determine end of questions section (we put answers there) */
-    if (!(ansp = skip_questions(header, dns_query_len))) {
-        return -1;
-    }
-    for (q = ntohs(header->qdcount); q != 0; q--) {
-        /* save pointer to name for copying into answers */
-        nameoffset = p - (unsigned char *)header;
-
-        if (!extract_name(header, dns_query_len, &p, c->namebuff, 1, 4)) {
-            return -1;
-        }
-        GETSHORT(qtype, p);
-        if (qtype == T_TXT && strcasecmp(c->provider_name, c->namebuff) == 0) {
-            // reply with signed certificate
-            const size_t size = 1 + sizeof(struct SignedCert);
-            static uint8_t **txt;
-
-            if(!txt) {
-                txt = calloc(c->signed_certs_count, sizeof(uint8_t *));
-                if(!txt) {
-                    return -1;
-                }
-                for (int i=0; i < c->signed_certs_count; i++) {
-                    if (!*(txt + i)) {
-                        *(txt + i) = malloc(size);
-                        if (!*(txt + i))
-                            return -1;
-                        **(txt + i) = sizeof(struct SignedCert);
-                        memcpy(*(txt + i) + 1, c->signed_certs + i, sizeof(struct SignedCert));
-                    }
-                }
-            }
-
-            for (int i=0; i < c->signed_certs_count; i++) {
-                if (add_resource_record
-                    (header, nameoffset, &ansp, 0, NULL, T_TXT, C_IN, "t", size,
-                     *(txt + i))) {
-                    anscount++;
-                } else {
-                    return -1;
-                }
-            }
-            /* done all questions, set up header and return length of result */
-            /* clear authoritative and truncated flags, set QR flag */
-            header->hb3 = (header->hb3 & ~(HB3_AA | HB3_TC)) | HB3_QR;
-            /* set RA flag */
-            header->hb4 |= HB4_RA;
-
-            SET_RCODE(header, NOERROR);
-            header->ancount = htons(anscount);
-            header->nscount = htons(0);
-            header->arcount = htons(0);
-            dns_query_len = ansp - (unsigned char *)header;
-
+    if (dnscrypt_self_serve_cert_file(c, header, &dns_query_len) == 0) {
             SendtoWithRetryCtx retry_ctx = {
                 .udp_request = udp_request,
                 .handle = udp_request->client_proxy_handle,
@@ -307,7 +247,6 @@ self_serve_cert_file(struct context *c, struct dns_header *header,
             };
             sendto_with_retry(&retry_ctx);
             return 0;
-        }
     }
     return -1;
 }


### PR DESCRIPTION
cert distribution code for UDP and TCP was duplicated. This refactors the code that deals with creating the DNS response into a separate function, letting the UDP/TCP code path deal with the transmission only.