### PR TITLE
Allow binding outgoing address

### DIFF
--- a/dnscrypt.h
+++ b/dnscrypt.h
@@ -101,10 +101,13 @@ typedef struct KeyPair_ {
 struct context {
     struct sockaddr_storage local_sockaddr;
     struct sockaddr_storage resolver_sockaddr;
+    struct sockaddr_storage outgoing_sockaddr;
     ev_socklen_t local_sockaddr_len;
     ev_socklen_t resolver_sockaddr_len;
+    ev_socklen_t outgoing_sockaddr_len;
     const char *resolver_address;
     const char *listen_address;
+    const char *outgoing_address;
     struct evconnlistener *tcp_conn_listener;
     struct event *tcp_accept_timer;
     struct event *udp_listener_event;

--- a/udp_request.c
+++ b/udp_request.c
@@ -531,6 +531,18 @@ udp_listener_bind(struct context *c)
     evutil_make_socket_nonblocking(c->udp_resolver_handle);
     udp_tune(c->udp_resolver_handle);
 
+    /* Bind source IP:port if --outgoing-address is provided */
+    if(c->outgoing_address &&
+       bind(c->udp_resolver_handle, (struct sockaddr *)&c->outgoing_sockaddr,
+            c->outgoing_sockaddr_len) != 0) {
+        logger(LOG_ERR, "Unable to bind (UDP) [%s]",
+            evutil_socket_error_to_string(evutil_socket_geterror
+                                          (c->udp_resolver_handle)));
+        evutil_closesocket(c->udp_resolver_handle);
+        c->udp_resolver_handle = -1;
+        return -1;
+    }
+
     RB_INIT(&c->udp_request_queue);
 
     return 0;


### PR DESCRIPTION
There is cases where it may be desireable to bind the source address of
outgoing connections.
This diff adds support for it.

When using UDP, this will cause the outgoing connection to listen on
IP:port vs *:port.
When using TCP, the outgoing connection is going to use the provide IP
vs letting the OS do it.

Tested by running a local unbound instance. When not binding to eth0 IP,
connections would be coming from 127.0.0.1, when using
--outgoing-address, connections would be coming from the provided IP.

Likewise with ipv6, tested using --outgoing-address=[::1] against a
resolver listening on ::1 and --outgoing-address=[::1]:portnumber.
This confirmed we would indeed bind to the provided port. Binding to 1
specific port for outgoing connection is not desirable, but provided
users only provide the IP to bind to, we can piggyback on the existing
`sockaddr_from_ip_and_port` function.