### PR TITLE
fix compile with cygwin64 error

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -1,6 +1,12 @@
 #include "debug.h"
 #include "logger.h"
 
+#ifdef __CYGWIN__
+#ifndef SA_ONSTACK
+#define SA_ONSTACK 0x08000000
+#endif
+#endif
+
 static char *assert_err  = "<no assertion failed>";
 static char *assert_file = "<no file>";
 static int assert_line   = 0;


### PR DESCRIPTION
New git version compile on Windows10 + cygwin64 will cause error:

error: �±SA_ONSTACK�² undeclared (first use in this function)

Fix refrence: https://github.com/antirez/redis/issues/232