### PR TITLE
cache: do not forget to include the server PK in the hash computation

### DIFF
--- a/dnscrypt.c
+++ b/dnscrypt.c
@@ -2,33 +2,40 @@
 
 typedef struct Cached_ {
     uint8_t pk[crypto_box_PUBLICKEYBYTES];
+    uint8_t server_pk[crypto_box_PUBLICKEYBYTES];
     uint8_t shared[crypto_box_BEFORENMBYTES];
 } Cached;
 
 static Cached cache[4096];
 
 static inline size_t
-h12(const uint8_t pk[crypto_box_PUBLICKEYBYTES], bool use_xchacha20)
+h12(const uint8_t pk[crypto_box_PUBLICKEYBYTES],
+    const uint8_t server_pk[crypto_box_PUBLICKEYBYTES], bool use_xchacha20)
 {
-    uint64_t a, b, c, d;
+    uint64_t a, b, c, d, e;
     uint32_t h;
 
     memcpy(&a, &pk[0], 8);  memcpy(&b, &pk[8], 8);
     memcpy(&c, &pk[16], 8); memcpy(&d, &pk[24], 8);
-    a ^= b ^ c ^ d;
-    h = ((uint32_t) a) ^ ((uint32_t) (a >> 32));
+    e = a ^ b ^ c ^ d;
+    memcpy(&a, &server_pk[0], 8);  memcpy(&b, &server_pk[8], 8);
+    memcpy(&c, &server_pk[16], 8); memcpy(&d, &server_pk[24], 8);
+    e ^= a ^ b ^ c ^ d;
+    h = ((uint32_t) e) ^ ((uint32_t) (e >> 32));
     return (size_t) (((h >> 20) ^ (h >> 8) ^ (h << 4) ^ use_xchacha20) & 0xfff);
 }
 
 static int
 cache_get(Cached ** const cached_p,
-          const uint8_t pk[crypto_box_PUBLICKEYBYTES], const bool use_xchacha20)
+          const uint8_t pk[crypto_box_PUBLICKEYBYTES],
+          const uint8_t server_pk[crypto_box_PUBLICKEYBYTES], const bool use_xchacha20)
 {
-    Cached *cached = &cache[h12(pk, use_xchacha20)];
+    Cached *cached = &cache[h12(pk, server_pk, use_xchacha20)];
 
     *cached_p = cached;
     if (memcmp(cached->pk, pk, crypto_box_PUBLICKEYBYTES - 1) == 0 &&
-        (cached->pk[crypto_box_PUBLICKEYBYTES - 1] ^ use_xchacha20) == pk[crypto_box_PUBLICKEYBYTES - 1]) {
+        (cached->pk[crypto_box_PUBLICKEYBYTES - 1] ^ use_xchacha20) == pk[crypto_box_PUBLICKEYBYTES - 1] &&
+        memcmp(cached->server_pk, server_pk, crypto_box_PUBLICKEYBYTES - 1) == 0) {
         return 1;
     }
     return 0;
@@ -36,13 +43,15 @@ cache_get(Cached ** const cached_p,
 
 static void
 cache_set(const uint8_t shared[crypto_box_BEFORENMBYTES],
-          const uint8_t pk[crypto_box_PUBLICKEYBYTES], const bool use_xchacha20)
+          const uint8_t pk[crypto_box_PUBLICKEYBYTES],
+          const uint8_t server_pk[crypto_box_PUBLICKEYBYTES], const bool use_xchacha20)
 {
     Cached *cached;
 
-    cache_get(&cached, pk, use_xchacha20);
+    cache_get(&cached, pk, server_pk, use_xchacha20);
     memcpy(cached->pk, pk, crypto_box_PUBLICKEYBYTES);
     cached->pk[crypto_box_PUBLICKEYBYTES - 1] ^= use_xchacha20;
+    memcpy(cached->server_pk, server_pk, crypto_box_PUBLICKEYBYTES);
     memcpy(cached->shared, shared, crypto_box_BEFORENMBYTES);
 }
 
@@ -252,7 +261,7 @@ dnscrypt_server_uncurve(struct context *c, const dnsccert *cert,
         (struct dnscrypt_query_header *)buf;
     Cached *cached;
 
-    if (cache_get(&cached, query_header->publickey, XCHACHA20_CERT(cert))) {
+    if (cache_get(&cached, query_header->publickey, cert->keypair->crypt_publickey, XCHACHA20_CERT(cert))) {
         memcpy(nmkey, cached->shared, crypto_box_BEFORENMBYTES);
     } else {
         memcpy(nmkey, query_header->publickey, crypto_box_PUBLICKEYBYTES);
@@ -269,7 +278,7 @@ dnscrypt_server_uncurve(struct context *c, const dnsccert *cert,
                 return -1;
             }
         }
-        cache_set(nmkey, query_header->publickey, XCHACHA20_CERT(cert));
+        cache_set(nmkey, query_header->publickey, cert->keypair->crypt_publickey, XCHACHA20_CERT(cert));
     }
 
     uint8_t nonce[crypto_box_NONCEBYTES];


### PR DESCRIPTION
Oops, the cache didn't play well with multiple keys being used simultaneously :)

My bad. This fixes it.