### PR TITLE
Include the signature in SignedCert

### DIFF
--- a/cert.h
+++ b/cert.h
@@ -14,13 +14,13 @@ struct SignedCert {
     uint8_t version_major[2];
     uint8_t version_minor[2];
 
+    uint8_t signature[crypto_sign_BYTES];
     // Signed Content
     uint8_t server_publickey[crypto_box_PUBLICKEYBYTES];
     uint8_t magic_query[8];
     uint8_t serial[4];
     uint8_t ts_begin[4];
     uint8_t ts_end[4];
-    uint8_t end[64];
 };
 
 struct Cert {
@@ -41,8 +41,6 @@ struct Cert {
 struct SignedCert *cert_build_cert(const uint8_t *crypt_publickey, int cert_file_expire_days, int use_xchacha20);
 int cert_sign(struct SignedCert *signed_cert,
               const uint8_t *provider_secretkey);
-int cert_unsign(struct SignedCert *signed_cert,
-                const uint8_t *provider_secretkey);
 void cert_display_txt_record_tinydns(struct SignedCert *signed_cert);
 void cert_display_txt_record(struct SignedCert *signed_cert);
 


### PR DESCRIPTION
I was very confused by the values in the `SignedCert` structure, that looked all wrong. The magic didn't match the public key, the timestamps were in year 1977 ...

Everything was shifted by 64 bytes due to the missing signature. There was 64 extra bytes at the end of the structure to compensate for that, but after the signature, the fields didn't match their initial value any more.

Anyway, this includes the signature in the structure, removes the 64 bytes at the end, and greatly simplifies the code. `unsign` was removed as well as it wasn't used anywhere.