### PR TITLE
Add missing checks

### DIFF
--- a/dnscrypt.c
+++ b/dnscrypt.c
@@ -302,7 +302,7 @@ dnscrypt_server_uncurve(struct context *c, const dnsccert *cert,
     }
 
     len -= DNSCRYPT_QUERY_HEADER_SIZE;
-    while (buf[--len] == 0);
+    while (len > 0 && buf[--len] == 0);
     if (buf[len] != 0x80) {
         return -1;
     }

--- a/tcp_request.c
+++ b/tcp_request.c
@@ -190,7 +190,7 @@ client_proxy_read_cb(struct bufferevent *const client_proxy_bev,
         if (dnscrypt_server_uncurve(c, tcp_request->cert,
                                     tcp_request->client_nonce,
                                     tcp_request->nmkey, dns_query,
-                                    &dns_query_len) != 0) {
+                                    &dns_query_len) != 0 || dns_query_len < DNS_HEADER_SIZE) {
             logger(LOG_WARNING, "Received a suspicious query from the client");
             tcp_request_kill(tcp_request);
             return;

--- a/udp_request.c
+++ b/udp_request.c
@@ -317,7 +317,7 @@ client_to_proxy_cb(evutil_socket_t client_proxy_handle, short ev_flags,
         if (dnscrypt_server_uncurve(c, udp_request->cert,
                                     udp_request->client_nonce,
                                     udp_request->nmkey, dns_query,
-                                    &dns_query_len) != 0) {
+                                    &dns_query_len) != 0 || dns_query_len < DNS_HEADER_SIZE) {
             logger(LOG_WARNING, "Received a suspicious query from the client");
             udp_request_kill(udp_request);
             return;


### PR DESCRIPTION
The missing checks after uncurve() don't seem to have any implications since the buffer has a fixed length.

The unpadding code may allow an attacker to cause a remote DoS though. This is not good.