### PR TITLE
Security

### DIFF
--- a/dnscrypt.c
+++ b/dnscrypt.c
@@ -408,59 +408,59 @@ dnscrypt_self_serve_cert_file(struct context *c, struct dns_header *header,
     if (!(ansp = skip_questions(header, *dns_query_len))) {
         return -1;
     }
-    do {
-        /* save pointer to name for copying into answers */
-        nameoffset = p - (unsigned char *)header;
 
-        if (!extract_name(header, *dns_query_len, &p, c->namebuff, 1, 4)) {
-            return -1;
-        }
-        GETSHORT(qtype, p);
-        if (qtype == T_TXT && strcasecmp(c->provider_name, c->namebuff) == 0) {
-            // reply with signed certificate
-            const size_t size = 1 + sizeof(struct SignedCert);
-            static uint8_t **txt;
+    /* save pointer to name for copying into answers */
+    nameoffset = p - (unsigned char *)header;
 
-            // Allocate static buffers containing the certificates.
-            // This is only called once the first time a TXT request is made.
+    if (!extract_name(header, *dns_query_len, &p, c->namebuff, 1, 4)) {
+        return -1;
+    }
+    GETSHORT(qtype, p);
+    if (qtype == T_TXT && strcasecmp(c->provider_name, c->namebuff) == 0) {
+        // reply with signed certificate
+        const size_t size = 1 + sizeof(struct SignedCert);
+        static uint8_t **txt;
+
+        // Allocate static buffers containing the certificates.
+        // This is only called once the first time a TXT request is made.
+        if(!txt) {
+            txt = calloc(c->signed_certs_count, sizeof(uint8_t *));
             if(!txt) {
-                txt = calloc(c->signed_certs_count, sizeof(uint8_t *));
-                if(!txt) {
-                    return -1;
-                }
-                for (int i=0; i < c->signed_certs_count; i++) {
-                    *(txt + i) = malloc(size);
-                    if (!*(txt + i))
-                        return -1;
-                    **(txt + i) = sizeof(struct SignedCert);
-                    memcpy(*(txt + i) + 1, c->signed_certs + i, sizeof(struct SignedCert));
-                }
+                return -1;
             }
-
             for (int i=0; i < c->signed_certs_count; i++) {
-                if (add_resource_record
-                    (header, nameoffset, &ansp, 0, NULL, T_TXT, C_IN, "t", size,
-                     *(txt + i))) {
-                    anscount++;
-                } else {
+                *(txt + i) = malloc(size);
+                if (!*(txt + i))
                     return -1;
-                }
+                **(txt + i) = sizeof(struct SignedCert);
+                memcpy(*(txt + i) + 1, c->signed_certs + i, sizeof(struct SignedCert));
             }
-            /* done all questions, set up header and return length of result */
-            /* clear authoritative and truncated flags, set QR flag */
-            header->hb3 = (header->hb3 & ~(HB3_AA | HB3_TC)) | HB3_QR;
-            /* set RA flag */
-            header->hb4 |= HB4_RA;
+        }
 
-            SET_RCODE(header, NOERROR);
-            header->ancount = htons(anscount);
-            header->nscount = htons(0);
-            header->arcount = htons(0);
-            *dns_query_len = ansp - (unsigned char *)header;
+        for (int i=0; i < c->signed_certs_count; i++) {
+            if (add_resource_record
+                (header, nameoffset, &ansp, 0, NULL, T_TXT, C_IN, "t", size,
+                    *(txt + i))) {
+                anscount++;
+            } else {
+                return -1;
+            }
+        }
+        /* done all questions, set up header and return length of result */
+        /* clear authoritative and truncated flags, set QR flag */
+        header->hb3 = (header->hb3 & ~(HB3_AA | HB3_TC)) | HB3_QR;
+        /* set RA flag */
+        header->hb4 |= HB4_RA;
 
-            return 0;
-          }
-    } while (0);
+        SET_RCODE(header, NOERROR);
+        header->ancount = htons(anscount);
+        header->nscount = htons(0);
+        header->arcount = htons(0);
+        *dns_query_len = ansp - (unsigned char *)header;
+
+        return 0;
+    }
+
     return -1;
 }
 

--- a/dnscrypt.c
+++ b/dnscrypt.c
@@ -400,11 +400,15 @@ dnscrypt_self_serve_cert_file(struct context *c, struct dns_header *header,
     unsigned int nameoffset;
     p = (unsigned char *)(header + 1);
     int anscount = 0;
+
+    if (ntohs(header->qdcount) != 1) {
+        return -1;
+    }
     /* determine end of questions section (we put answers there) */
     if (!(ansp = skip_questions(header, *dns_query_len))) {
         return -1;
     }
-    for (q = ntohs(header->qdcount); q != 0; q--) {
+    do {
         /* save pointer to name for copying into answers */
         nameoffset = p - (unsigned char *)header;
 
@@ -456,7 +460,7 @@ dnscrypt_self_serve_cert_file(struct context *c, struct dns_header *header,
 
             return 0;
           }
-    }
+    } while (0);
     return -1;
 }
 

--- a/dnscrypt.c
+++ b/dnscrypt.c
@@ -395,7 +395,6 @@ dnscrypt_self_serve_cert_file(struct context *c, struct dns_header *header,
 {
     unsigned char *p;
     unsigned char *ansp;
-    int q;
     int qtype;
     unsigned int nameoffset;
     p = (unsigned char *)(header + 1);

--- a/tcp_request.c
+++ b/tcp_request.c
@@ -112,7 +112,8 @@ static void
 client_proxy_read_cb(struct bufferevent *const client_proxy_bev,
                      void *const tcp_request_)
 {
-    uint8_t dns_query[DNS_MAX_PACKET_SIZE_TCP - 2U];
+    const size_t sizeof_dns_query = DNS_MAX_PACKET_SIZE_TCP - 2U;
+    static uint8_t *dns_query = NULL;
     uint8_t dns_query_len_buf[2];
     uint8_t dns_curved_query_len_buf[2];
     TCPRequest *tcp_request = tcp_request_;
@@ -122,6 +123,9 @@ client_proxy_read_cb(struct bufferevent *const client_proxy_bev,
     size_t dns_query_len;
     size_t max_query_size;
 
+    if (dns_query == NULL && (dns_query = sodium_malloc(sizeof_dns_query)) == NULL) {
+        return;
+    }
     if (tcp_request->status.has_dns_query_len == 0) {
         debug_assert(evbuffer_get_length(input) >= (size_t) 2U);
         evbuffer_remove(input, dns_query_len_buf, sizeof dns_query_len_buf);
@@ -155,14 +159,14 @@ client_proxy_read_cb(struct bufferevent *const client_proxy_bev,
         tcp_request_kill(tcp_request);
         return;
     }
-    debug_assert(dns_query_len <= sizeof dns_query);
+    debug_assert(dns_query_len <= sizeof_dns_query);
     if ((ssize_t) evbuffer_remove(tcp_request->proxy_resolver_query_evbuf,
                                   dns_query, dns_query_len)
         != (ssize_t) dns_query_len) {
         tcp_request_kill(tcp_request);
         return;
     }
-    max_query_size = sizeof dns_query;
+    max_query_size = sizeof_dns_query;
     debug_assert(max_query_size < DNS_MAX_PACKET_SIZE_TCP);
     debug_assert(SIZE_MAX - DNSCRYPT_MAX_PADDING - DNSCRYPT_QUERY_HEADER_SIZE
               > dns_query_len);
@@ -176,7 +180,7 @@ client_proxy_read_cb(struct bufferevent *const client_proxy_bev,
         return;
     }
     debug_assert(max_len <= DNS_MAX_PACKET_SIZE_TCP - 2U);
-    debug_assert(max_len <= sizeof dns_query);
+    debug_assert(max_len <= sizeof_dns_query);
     debug_assert(dns_query_len <= max_len);
 
     // decrypt if encrypted
@@ -271,9 +275,14 @@ resolver_proxy_read_cb(struct bufferevent *const proxy_resolver_bev,
     struct context *c = tcp_request->context;
     struct evbuffer *input = bufferevent_get_input(proxy_resolver_bev);
     size_t available_size;
-    uint8_t dns_reply[DNS_MAX_PACKET_SIZE_TCP - 2U];
+    const size_t sizeof_dns_reply = DNS_MAX_PACKET_SIZE_TCP - 2U;
+    static uint8_t *dns_reply = NULL;
     size_t dns_reply_len;
 
+    if (dns_reply == NULL && (dns_reply = sodium_malloc(sizeof_dns_reply)) == NULL) {
+        tcp_request_kill(tcp_request);
+        return;
+    }
     logger(LOG_DEBUG, "Resolver read callback.");
     if (tcp_request->status.has_dns_reply_len == 0) {
         debug_assert(evbuffer_get_length(input) >= (size_t) 2U);


### PR DESCRIPTION
Hi,

The function that creates a TXT response with the certificates repeats the operation as many times as questions found in the query.

First, there are no reasons to have more than one question. If that happens, it is definitely unexpected.

More importantly, adding the records doesn't seem to check that we still have enough space in the response buffer. I may have overlooked something, but it looks like sending many questions will result in a buffer overflow. This is user-controlled data, written onto the stack, this is scary from a security perspective.

This diff accepts a single question. While still relying on the assertion that the response buffer is large enough to hold the question and all the certificates, this is a temporary fix to avoid going out of bounds.

On-the-stack buffers holding user-controlled data are also replaced with guarded heap allocations using `sodium_malloc()`. First, it's not on the stack any more which makes exploitation more difficult, but more importantly, `sodium_malloc()` adds a guard page at the end of the allocated buffers. So that if the page is hit, the server will kill itself instead of possibly leading to more serious security issues.