### PR TITLE
Fixes multiple certs issue

### DIFF
--- a/dnscrypt.c
+++ b/dnscrypt.c
@@ -66,7 +66,7 @@ find_cert(const struct context *c,
     if (dns_query_len <= DNSCRYPT_QUERY_HEADER_SIZE) {
         return NULL;
     }
-    for (i = 0U; i < c->signed_certs_count; i++) {
+    for (i = 0U; i < c->certs_count; i++) {
         if (memcmp(certs[i].magic_query, magic_query, DNSCRYPT_MAGIC_HEADER_LEN) == 0) {
             return &certs[i];
         }

--- a/dnscrypt.h
+++ b/dnscrypt.h
@@ -149,6 +149,7 @@ struct context {
     struct SignedCert *signed_certs;
     size_t signed_certs_count;
     dnsccert *certs;
+    size_t certs_count;
     uint8_t provider_publickey[crypto_sign_ed25519_PUBLICKEYBYTES];
     uint8_t provider_secretkey[crypto_sign_ed25519_SECRETKEYBYTES];
     char *crypt_secretkey_file;

--- a/main.c
+++ b/main.c
@@ -231,7 +231,7 @@ filter_signed_certs(struct context *c)
                 filtered_certs[j].version_minor[0] == c->signed_certs[i].version_minor[0] &&
                 filtered_certs[j].version_minor[1] == c->signed_certs[i].version_minor[1]) {
                 found = 1;
-                if (filtered_certs[j].serial < c->signed_certs[i].serial) {
+                if (ntohl(*(uint32_t *)filtered_certs[j].serial) < ntohl(*(uint32_t *)c->signed_certs[i].serial)) {
                     filtered_certs[j] = c->signed_certs[i];
                 }
             }
@@ -295,6 +295,7 @@ match_cert_to_keys(struct context *c) {
     size_t keypair_id, signed_cert_id, cert_id;
 
     c->certs = sodium_allocarray(c->signed_certs_count, sizeof *c->certs);
+    c->certs_count = c->signed_certs_count;
     cert_id = 0U;
 
     for(keypair_id=0; keypair_id < c->keypairs_count; keypair_id++) {

--- a/version.h
+++ b/version.h
@@ -2,6 +2,6 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-const char *the_version = "0.4.0-4.g9cf954e";
+const char *the_version = "0.4.0-5.g100b339";
 
 #endif


### PR DESCRIPTION
- find_cert() should search in all certs.
- filter_signed_certs() should convert serial to uint32_t before comparison.