### PR TITLE
Log level of "Short query received" changed to debug

### DIFF
--- a/tcp_request.c
+++ b/tcp_request.c
@@ -137,7 +137,7 @@ client_proxy_read_cb(struct bufferevent *const client_proxy_bev,
     debug_assert(tcp_request->status.has_dns_query_len != 0);
     dns_query_len = tcp_request->dns_query_len;
     if (dns_query_len < (size_t) DNS_HEADER_SIZE) {
-        logger(LOG_WARNING, "Short query received");
+        logger(LOG_DEBUG, "Short query received");
         tcp_request_kill(tcp_request);
         return;
     }

--- a/udp_request.c
+++ b/udp_request.c
@@ -300,7 +300,7 @@ client_to_proxy_cb(evutil_socket_t client_proxy_handle, short ev_flags,
     }
 
     if (nread < (ssize_t) DNS_HEADER_SIZE || nread > sizeof_dns_query) {
-        logger(LOG_WARNING, "Short query received");
+        logger(LOG_DEBUG, "Short query received");
         udp_request_kill(udp_request);
         return;
     }


### PR DESCRIPTION
_dnscrypt-wrapper_ in [dnscrypt-server-docker](https://github.com/jedisct1/dnscrypt-server-docker) produces hundreds messages of

> [warning] [udp_request.c:302] Short query received

in the Docker logs.

In my opinion that's not a warning, so output them only in debug.