### PR TITLE
TCP_REQUEST_BACKLOG

### DIFF
--- a/tcp_request.h
+++ b/tcp_request.h
@@ -6,7 +6,7 @@
 #define DNS_MAX_PACKET_SIZE_TCP (65535U + 2U)
 
 #ifndef TCP_REQUEST_BACKLOG
-# define TCP_REQUEST_BACKLOG 128
+# define TCP_REQUEST_BACKLOG -1
 #endif
 
 struct context;


### PR DESCRIPTION
Error at the server when backlog value too small:

~~~
TCP: request_sock_TCP: Possible SYN flooding on port 1443. Sending cookies.  Check SNMP counters
~~~

https://libevent.org/doc/listener_8h.html#aa07ae1878cf56d58579b025dd1620c91

~~~
backlog | Passed  to the listen() call to determine the length of the acceptable  connection backlog. Set to -1 for a reasonable default. Set to 0 if the  socket is already listening.
~~~

Tested with https://jp.tiar.app, no more syn flooding error observed.


