### PR TITLE
docs: fix simple typo, retransmision -> retransmission

### DIFF
--- a/rfc1035.c
+++ b/rfc1035.c
@@ -169,7 +169,7 @@ extract_name(struct dns_header *header, size_t plen, unsigned char **pp,
 }
 
 /* Hash the question section. This is used to safely detect query
-   retransmision and to detect answers to questions we didn't ask, which
+   retransmission and to detect answers to questions we didn't ask, which
    might be poisoning attacks. Note that we decode the name rather
    than hash the raw bytes, since replies might be compressed differently.
    We ignore case in the names for the same reason. Return all-ones


### PR DESCRIPTION
There is a small typo in rfc1035.c.

Should read `retransmission` rather than `retransmision`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md